### PR TITLE
waking up call working for home and app pages

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -16,6 +16,7 @@ app.use(express.json());
 app.use(cors())
 
 app.get("/api/wakeup", (req, res) => {
+  log.info("Wake up call received");
   res.json("Waking up server");
 });
 

--- a/web-nextjs/src/app/app/appPageFunctions.ts
+++ b/web-nextjs/src/app/app/appPageFunctions.ts
@@ -3,6 +3,7 @@ import type { WeatherNotificationSubscription } from '../../../../types/weatherT
 const apiAddress = "https://weather-app-server-2k0c.onrender.com" || 
   "http://localhost:8081"
 
+  
 export async function sendSubscriptionRequest(request : WeatherNotificationSubscription) {
   console.log("sending request: ", request)
 
@@ -61,6 +62,14 @@ export function checkUserData(request : WeatherNotificationSubscription) {
     throw new Error("Location not found!") 
   }
 }
+
+
+export async function sendWakeupCall() {
+    console.log("sending wakeup call")
+    const res = await fetch(`${apiAddress}/api/wakeup`);
+    const result = await res.json();
+    console.log(result);
+  }
 
 
 

--- a/web-nextjs/src/app/app/page.tsx
+++ b/web-nextjs/src/app/app/page.tsx
@@ -10,8 +10,7 @@ import type { ShownContraints, InputContraints } from "./types";
 import background from "./backgrounds/background5.jpg"
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { checkUserData, getCoordsFromLocation, sendSubscriptionRequest } from "./appPageFunctions";
-import { sendWakeupCall } from "../homePageFunctions";
+import { checkUserData, getCoordsFromLocation, sendSubscriptionRequest, sendWakeupCall } from "./appPageFunctions";
 
 
 export default function MainApp() {

--- a/web-nextjs/src/app/app/page.tsx
+++ b/web-nextjs/src/app/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, CSSProperties } from "react"
+import { useState, CSSProperties, useEffect } from "react"
 import Footer from "../Footer"
 import Navbar from "../Navbar"
 import ConstraitCheckbox from "./ConstraintCheckbox"
@@ -11,6 +11,7 @@ import background from "./backgrounds/background5.jpg"
 import { ToastContainer, toast } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import { checkUserData, getCoordsFromLocation, sendSubscriptionRequest } from "./appPageFunctions";
+import { sendWakeupCall } from "../homePageFunctions";
 
 
 export default function MainApp() {
@@ -33,7 +34,6 @@ export default function MainApp() {
     showTemp: true,
     showHumidity: true
   }
-
   const inititialInputConstraints: InputContraints = {
     emailInput: "",
     locationInput: "",
@@ -48,6 +48,12 @@ export default function MainApp() {
 
   const [ shownConstraints, setShownConstraints ] = useState<ShownContraints>(initialShownConstraints);
   const [ inputConstraints, setInputConstraints ] = useState<InputContraints>(inititialInputConstraints);
+
+
+  useEffect(() => {
+    sendWakeupCall();
+  }, []);
+
 
   function handleCheckboxChange(clickedCheckbox: keyof ShownContraints) {
     setShownConstraints(prevState => {
@@ -65,12 +71,14 @@ export default function MainApp() {
     });
   };
 
+
   function handleInputChange(currentInput: keyof InputContraints, value: string) {
     setInputConstraints(prevState => ({
       ...prevState,
       [currentInput]: value
     }));
   }
+
 
   function handleWindDirInputChange(e: React.ChangeEvent<HTMLInputElement>) {
     const value = e.target.value as WindDirection;
@@ -90,6 +98,7 @@ export default function MainApp() {
         };
     });
   }
+
 
   function checkConstraints(request : WeatherNotificationSubscription) {
     if (shownConstraints.showWindDir) {
@@ -136,6 +145,7 @@ export default function MainApp() {
 
     return true;
   }
+
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();

--- a/web-nextjs/src/app/homePageFunctions.ts
+++ b/web-nextjs/src/app/homePageFunctions.ts
@@ -1,9 +1,0 @@
-const apiAddress = "https://weather-app-server-2k0c.onrender.com" || 
-  "http://localhost:8081"
-
-export async function sendWakeupCall() {
-    console.log("sending wakeup call")
-    const res = await fetch(`${apiAddress}/api/wakeup`);
-    const result = await res.json();
-    console.log(result);
-  }

--- a/web-nextjs/src/app/homePageFunctions.ts
+++ b/web-nextjs/src/app/homePageFunctions.ts
@@ -1,0 +1,9 @@
+const apiAddress = "https://weather-app-server-2k0c.onrender.com" || 
+  "http://localhost:8081"
+
+export async function sendWakeupCall() {
+    console.log("sending wakeup call")
+    const res = await fetch(`${apiAddress}/api/wakeup`);
+    const result = await res.json();
+    console.log(result);
+  }

--- a/web-nextjs/src/app/page.tsx
+++ b/web-nextjs/src/app/page.tsx
@@ -1,8 +1,11 @@
-import { CSSProperties } from 'react';
+"use client";
+
+import { CSSProperties, useEffect } from 'react';
 import Link from 'next/link';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import homepagePhoto from './homepage-photo.jpg';
+import { sendWakeupCall } from './homePageFunctions';
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
@@ -23,6 +26,10 @@ export default function Home() {
     backdropFilter: 'blur(1px)',
     color: 'white'
   }
+
+  useEffect(() => {
+    sendWakeupCall();
+  }, []);
     
   return (
     <main className="flex flex-col justify-between min-h-screen bg-cover bg-center" style={{backgroundImage: `url(${homepagePhoto.src})`}}>

--- a/web-nextjs/src/app/page.tsx
+++ b/web-nextjs/src/app/page.tsx
@@ -1,17 +1,15 @@
-"use client";
-
-import { CSSProperties, useEffect } from 'react';
+import { CSSProperties } from 'react';
 import Link from 'next/link';
 import Navbar from './Navbar';
 import Footer from './Footer';
 import homepagePhoto from './homepage-photo.jpg';
-import { sendWakeupCall } from './homePageFunctions';
 import type { Metadata } from 'next'
 
 export const metadata: Metadata = {
   title: 'Adventure Alarm | Home',
   description: 'Adventure Alarm is a weather notification app that allows you to set up notifications for weather conditions suited to your adventures.',
 }
+
 
 export default function Home() {
 
@@ -26,10 +24,6 @@ export default function Home() {
     backdropFilter: 'blur(1px)',
     color: 'white'
   }
-
-  useEffect(() => {
-    sendWakeupCall();
-  }, []);
     
   return (
     <main className="flex flex-col justify-between min-h-screen bg-cover bg-center" style={{backgroundImage: `url(${homepagePhoto.src})`}}>


### PR DESCRIPTION
Wake up call is now working. Have added this for both the home page and the app page.

Because I have the server hosted on the free tier of Render it winds down when it is not being used. This means when a request is sent to it it takes some time to spin back up and causes a big delay. By sending a request to it as soon as the page is loaded it should have spun up properly by the time a user is ready to submit their form